### PR TITLE
feat: 결제 서비스 및 엔티티 구조 업데이트

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.42/8365263844ebb62398e0dc33057ba10ba472d3b8/lombok-1.18.42.jar" />
+        </processorPath>
+        <module name="Cloudpos_main" />
+        <module name="Cloudpos_test" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="Cloudpos" options="-parameters" />
+      <module name="Cloudpos_main" options="-parameters" />
+      <module name="Cloudpos_test" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/CloudPos.iml" filepath="$PROJECT_DIR$/.idea/CloudPos.iml" />
+    </modules>
+  </component>
+</project>

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/config/RestTemplateConfig.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/config/RestTemplateConfig.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.config;
+
+public class RestTemplateConfig {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/controller/DiscountPolicyController.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/controller/DiscountPolicyController.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.controller;
+
+public class DiscountPolicyController {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/controller/TossPaymentController.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/controller/TossPaymentController.java
@@ -1,0 +1,59 @@
+package org.example.cloudpos.payment.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.cloudpos.payment.dto.TossPaymentRequest;
+import org.example.cloudpos.payment.dto.TossPaymentResponse;
+import org.example.cloudpos.payment.service.TossPaymentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * <h2>TossPaymentController</h2>
+ *
+ * 토스페이먼츠 결제 관련 요청을 처리하는 REST 컨트롤러입니다.
+ *
+ * <p>프론트엔드에서 결제 완료 후 전달된 paymentKey, orderId, amount 정보를
+ * TossPaymentService로 전달해 결제 승인을 수행합니다.</p>
+ *
+ * <p>엔드포인트 예시:</p>
+ * POST /payments/toss/confirm
+ *
+ * 요청 예시:
+ * <pre>
+ * {
+ *   "paymentKey": "pay_2025110312345678abcd",
+ *   "orderId": "order_001",
+ *   "amount": 30000
+ * }
+ * </pre>
+ *
+ * 응답 예시:
+ * <pre>
+ * {
+ *   "paymentKey": "pay_2025110312345678abcd",
+ *   "orderId": "order_001",
+ *   "status": "DONE",
+ *   "method": "카드",
+ *   "totalAmount": 30000,
+ *   "approvedAt": "2025-11-03T12:34:56+09:00"
+ * }
+ * </pre>
+ */
+
+@Slf4j
+@RestController
+@RequestMapping("/payments/toss")
+@RequiredArgsConstructor
+public class TossPaymentController {
+
+    private final TossPaymentService tossPaymentService;
+
+    // 토스 결제 승인 API
+    @PostMapping("/confirm")
+    public ResponseEntity<TossPaymentResponse> confirmPayment(@RequestBody TossPaymentRequest request) {
+        log.info("[POST] /api/payments/toss/confirm 호출됨");
+        TossPaymentResponse response = tossPaymentService.confirmPayment(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/DiscountPolicy.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/DiscountPolicy.java
@@ -2,6 +2,7 @@ package org.example.cloudpos.payment.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,7 +37,7 @@ public class DiscountPolicy {
     @Column(name = "type")
     private DiscountType discountType; // 퍼센트 or 금액
 
-    private BigDecimal value; // 할인 값
+    private int value; // 할인 값
 
     @Column(name = "is_active")
     private Boolean isActive;  // 정책 활성 여부
@@ -52,6 +53,17 @@ public class DiscountPolicy {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Builder
+    public DiscountPolicy(String name, DiscountType discountType, int value, Boolean isActive,
+                          LocalDateTime validFrom, LocalDateTime validTo) {
+        this.name = name;
+        this.discountType = discountType;
+        this.value = value;
+        this.isActive = isActive;
+        this.validFrom = validFrom;
+        this.validTo = validTo;
+    }
 
     @PrePersist
     public void prePersist() {

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/Payment.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/Payment.java
@@ -1,9 +1,7 @@
 package org.example.cloudpos.payment.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -33,8 +31,8 @@ public class Payment {
 
     private Long orderId; // 주문과 관련된 엔티티로 추후에 연관관계 매핑예정
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "payment_method")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_method_id")
     private PaymentMethod paymentMethod;
 
     @Enumerated(EnumType.STRING)
@@ -42,13 +40,21 @@ public class Payment {
     private PaymentStatus paymentStatus;
 
     @Column(name = "amount_final")
-    private BigDecimal amountFinal;
+    private int amountFinal;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Builder
+    public Payment(Long orderId, PaymentMethod paymentMethod, PaymentStatus paymentStatus, int amountFinal) {
+        this.orderId = orderId;
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = paymentStatus;
+        this.amountFinal = amountFinal;
+    }
 
     @PrePersist
     public void prePersist() {

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/PaymentDiscount.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/PaymentDiscount.java
@@ -41,7 +41,7 @@ public class PaymentDiscount {
     @JoinColumn(name = "discount_policy_id")
     private DiscountPolicy discountPolicy; // 할인 정책 참조
 
-    private BigDecimal discountAmount; // 실제 할인 금액
+    private int discountAmount; // 실제 할인 금액
     private LocalDateTime createdAt;
 
     @PrePersist

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/PaymentMethod.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/PaymentMethod.java
@@ -1,13 +1,57 @@
 package org.example.cloudpos.payment.domain;
-/**
- * PaymentMethod
- *
- * 결제 수단을 정의하는 Enum 클래스.
- * 결제 시 어떤 방식으로 처리되었는지를 명시함.
- *
- * CASH : 현금 결제
- * CARD : 카드 결제
- */
-public enum PaymentMethod {
-    CASH,CARD
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "payment_method")
+public class PaymentMethod {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String code;  // 결제 수단(CARD,CASH,KAKAO_PAY)등등
+
+    @Column(nullable = false)
+    private String name; // 사용자에게 보여주기용
+
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = true;
+
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+    //비즈니스 메서드
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/TossPayment.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/domain/TossPayment.java
@@ -1,0 +1,67 @@
+package org.example.cloudpos.payment.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * TossPayments 결제 정보 엔티티
+ *
+ * 토스페이먼츠 API를 통해 승인된 결제 정보를 저장합니다.
+ * 내부 Payment 엔티티와 1:1로 연결되어 실제 결제 결과를 기록합니다.
+ *
+ * 예시:
+ *  - paymentKey: 토스 서버가 발급한 고유 결제 키
+ *  - method: 카드, 카카오페이, 토스페이, 계좌이체 등
+ *  - status: READY, DONE, CANCELED, PARTIAL_CANCELED 등
+ *  - totalAmount: 총 결제 금액 (원 단위)
+ *  - approvedAt: 결제 승인 시각
+ */
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "toss_payment")
+public class TossPayment {
+
+    @Id
+    @Column(name = "payment_key", nullable = false, unique = true)
+    private String paymentKey; //토스에서 발급한 고유 결제 키
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id" , nullable = false)
+    private Payment payment;
+
+    @Column(name = "total_amount", nullable = false)
+    private long totalAmount; // 총 결제 금액
+
+    @Column(nullable = false)
+    private String method; // 결제수단(무엇으로 결제를 했는가)
+
+    @Column(nullable = false)
+    private String status; // 결제상태
+
+    @Column(name = "requested_at")
+    private LocalDateTime requestedAt; // 결제 요청 시각
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt; // 결제 승인 시각
+
+    @Column(name = "failure_reason")
+    private String failureReason; // 결제 실패 사유(토스페이는 결제실패시 이유를 알려줌)
+
+    @Column(name = "is_cancelable")
+    private boolean isCancelable; // 결제 취소 가능여부
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt; // 결제 생성 시각
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/DiscountPolicyRequest.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/DiscountPolicyRequest.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.dto;
+
+public class DiscountPolicyRequest {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/DiscountPolicyResponse.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/DiscountPolicyResponse.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.dto;
+
+public class DiscountPolicyResponse {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/PaymentRequest.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/PaymentRequest.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.dto;
+
+public class PaymentRequest {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/PaymentResponse.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/PaymentResponse.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.dto;
+
+public class PaymentResponse {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/TossPaymentRequest.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/TossPaymentRequest.java
@@ -1,0 +1,39 @@
+package org.example.cloudpos.payment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * <h2>TossPaymentRequest</h2>
+ *
+ * 프론트엔드에서 결제 완료 후 백엔드로 전달되는
+ * 토스페이먼츠 결제 승인 요청 DTO 입니다.
+ *
+ * <p>토스 결제 위젯에서 결제가 완료되면, 프론트에서는
+ * paymentKey, orderId, amount 값을 백엔드로 전달해야 합니다.</p>
+ *
+ * 예시 요청:
+ * <pre>
+ * {
+ *   "paymentKey": "pay_20251031235959xYzAbC",
+ *   "orderId": "12345",
+ *   "amount": 30000
+ * }
+ * </pre>
+ */
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class TossPaymentRequest {
+
+    //토스에서 발급한 결제 고유 키
+    private String paymentKey;
+
+    //내부 시스템에서 관리하는 주문 ID
+    private String orderId;
+
+    //결제 총금액
+    private  long amount;
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/TossPaymentResponse.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/dto/TossPaymentResponse.java
@@ -1,0 +1,68 @@
+package org.example.cloudpos.payment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * <h2>TossPaymentResponse</h2>
+ *
+ * 토스페이먼츠 결제 승인 API 응답을 매핑하는 DTO입니다.
+ *
+ * <p>토스 서버로부터 받은 JSON 응답을 매핑하며,
+ * 결제 승인 성공 시 결제 상태, 금액, 승인 시간 등의 정보를 담습니다.</p>
+ *
+ * <p>응답 예시:</p>
+ * <pre>
+ * {
+ *   "version": "2022-11-16",
+ *   "paymentKey": "pay_2025110312345678abcd",
+ *   "orderId": "order_001",
+ *   "orderName": "삼성 모니터 27인치",
+ *   "status": "DONE",
+ *   "method": "카드",
+ *   "totalAmount": 30000,
+ *   "approvedAt": "2025-11-03T12:00:00+09:00",
+ *   "easyPay": {
+ *     "provider": "토스페이",
+ *     "amount": 30000
+ *   },
+ *   "receipt": {
+ *     "url": "https://sandbox.tosspayments.com/receipt/pay_..."
+ *   }
+ * }
+ * </pre>
+
+ */
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class TossPaymentResponse {
+
+    private String version;       // 응답 버전
+    private String paymentKey;    // 결제 키
+    private String orderId;       // 주문 ID
+    private String orderName;     // 주문명
+    private String status;        // 결제 상태
+    private String method;        // 결제수단
+    private long totalAmount;     // 결제 금액
+    private String approvedAt;    // 결제 승인 시각
+    private EasyPay easyPay;      // 간편결제 정보 (토스페이, 네이버페이 등)
+    private Receipt receipt;      // 영수증 URL 정보
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class EasyPay {
+        private String provider;  // 예: 토스페이, 네이버페이 등
+        private long amount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class Receipt {
+        private String url;       // 영수증 조회 URL
+    }
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/repository/PaymentMethodRepository.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/repository/PaymentMethodRepository.java
@@ -1,0 +1,7 @@
+package org.example.cloudpos.payment.repository;
+
+import org.example.cloudpos.payment.domain.PaymentMethod;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentMethodRepository extends JpaRepository<PaymentMethod, Long> {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/repository/PaymentRepository.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/repository/PaymentRepository.java
@@ -3,6 +3,9 @@ package org.example.cloudpos.payment.repository;
 import org.example.cloudpos.payment.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
 /**
  * PaymentRepository
  *
@@ -16,4 +19,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByOrderId(String orderId);
+
 }

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/repository/TossPaymentRepository.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/repository/TossPaymentRepository.java
@@ -1,0 +1,9 @@
+package org.example.cloudpos.payment.repository;
+
+import org.example.cloudpos.payment.domain.TossPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TossPaymentRepository extends JpaRepository<TossPayment, Long> {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/service/DiscountPolicyService.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/service/DiscountPolicyService.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.service;
+
+public class DiscountPolicyService {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/service/PaymentService.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/service/PaymentService.java
@@ -1,0 +1,4 @@
+package org.example.cloudpos.payment.service;
+
+public class PaymentService {
+}

--- a/Cloudpos/src/main/java/org/example/cloudpos/payment/service/TossPaymentService.java
+++ b/Cloudpos/src/main/java/org/example/cloudpos/payment/service/TossPaymentService.java
@@ -1,0 +1,109 @@
+package org.example.cloudpos.payment.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.cloudpos.payment.domain.Payment;
+import org.example.cloudpos.payment.domain.TossPayment;
+import org.example.cloudpos.payment.dto.TossPaymentRequest;
+import org.example.cloudpos.payment.dto.TossPaymentResponse;
+import org.example.cloudpos.payment.repository.PaymentRepository;
+import org.example.cloudpos.payment.repository.TossPaymentRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+/**
+ * <h2>TossPaymentService</h2>
+ *
+ * 토스페이먼츠 결제 승인 로직을 담당하는 서비스 클래스입니다.
+ *
+ * <p>프론트엔드에서 받은 paymentKey, orderId, amount 값을 이용해
+ * Toss Payments 서버로 결제 승인 API를 호출하고, 승인 결과를 반환합니다.</p>
+ *
+ */
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TossPaymentService {
+
+    @Value("${toss.base-url}")
+    private String tossBaseUrl;
+
+    @Value("${toss.secret-key}")
+    private String secretKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final TossPaymentRepository tossPaymentRepository;
+    private final PaymentRepository paymentRepository;
+
+    //토스 결제 승인 요청
+    public TossPaymentResponse confirmPayment(TossPaymentRequest request) {
+        log.info("[TOSS 결제 승인 요청] paymentKey={}, orderId={}, amount={}",
+                request.getPaymentKey(), request.getOrderId(), request.getAmount());
+
+        try {
+            // 인증 헤더 생성
+            String encodedAuth = Base64.getEncoder()
+                    .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Basic " + encodedAuth);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            HttpEntity<TossPaymentRequest> entity = new HttpEntity<>(request, headers);
+
+            // Toss 서버 결제 승인 API 호출
+            String confirmUrl = tossBaseUrl + "/confirm";
+
+            ResponseEntity<TossPaymentResponse> response = restTemplate.exchange(
+                    confirmUrl, HttpMethod.POST, entity, TossPaymentResponse.class
+            );
+
+            TossPaymentResponse body = response.getBody();
+            if (body == null) {
+                throw new RuntimeException("Toss 결제 승인 응답이 비어있습니다.");
+            }
+
+            log.info("[TOSS 결제 승인 성공] paymentKey={}, status={}",
+                    body.getPaymentKey(), body.getStatus());
+
+
+            //  Payment 조회
+            Payment payment = paymentRepository.findByOrderId(body.getOrderId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 주문을 찾을 수 없습니다."));
+
+            //  TossPayment 엔티티 생성 및 저장
+            TossPayment tossPayment = TossPayment.builder()
+                    .paymentKey(body.getPaymentKey())
+                    .payment(payment)
+                    .totalAmount(body.getTotalAmount())
+                    .method(body.getMethod())
+                    .status(body.getStatus())
+                    .requestedAt(LocalDateTime.now())
+                    .approvedAt(LocalDateTime.parse(body.getApprovedAt()))
+                    .isCancelable(true)
+                    .build();
+
+            tossPaymentRepository.save(tossPayment);
+            log.info("[DB 저장 완료] paymentKey={}, totalAmount={}",
+                    tossPayment.getPaymentKey(), tossPayment.getTotalAmount());
+
+            return body;
+
+        } catch (HttpClientErrorException e) {
+            log.error("[TOSS 결제 승인 실패] {}", e.getResponseBodyAsString());
+            throw new RuntimeException("Toss 결제 승인 실패: " + e.getResponseBodyAsString());
+        } catch (Exception e) {
+            log.error("[서버 내부 오류] {}", e.getMessage(), e);
+            throw new RuntimeException("서버 내부 오류 발생: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### 💡 작업 내용
- 결제(Payment) 도메인 엔티티 및 관련 서비스 로직 추가
- PaymentMethod, PaymentStatus Enum 정의
- DiscountPolicy, PaymentDiscount 등 연관 엔티티 매핑
- 결제 생성 및 승인 흐름 기본 구조 구현

### 🧩 변경 이유
- 결제 모듈 초기 설계 반영
- 주문(Order) 및 할인 정책과의 관계를 고려한 도메인 구조 확립
- 추후 TossPayments 연동을 위한 기초 작업

### ✅ 참고 사항
- 아직 결제 승인/취소 API는 Stub 형태로 남겨둠
- 이후 결제 승인 로직 및 외부 연동 추가 예정
